### PR TITLE
🐍 remove passmanager.pyi from LapisPythonSources

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,7 +27,6 @@ declare_mlir_python_sources(LapisPythonSources.linalg_kokkos_backend
     linalg_kokkos_backend/abc.py
     linalg_kokkos_backend/KokkosBackend.py
     linalg_kokkos_backend/KokkosBackendJustMLIRDump.py
-    _mlir_libs/_mlir/passmanager.pyi
 )
 
 declare_mlir_python_sources(LapisPythonSources.tools


### PR DESCRIPTION
The lapis project won't build via ninja giving error there is duplicate
target _mlir_libs/_mlir/passmanager.pyi.
The likely cause of this error is:
`LapisPythonSources.linalg_kokkos_backend` and `MLIRPythonSources`
both produce this target.