### PR TITLE
Fix a no matching function compilation error

### DIFF
--- a/mlir/include/mlir/ExecutionEngine/PartTensor/Storage.h
+++ b/mlir/include/mlir/ExecutionEngine/PartTensor/Storage.h
@@ -178,7 +178,7 @@ PartTensorStorage<P, I, V> *PartTensorStorage<P, I, V>::newFromCOO(
   assert(partDataLength > 0 && "Got zero for partition data");
   assert(dimRank > 0 && "Got zero for dimension rank");
   std::vector<uint64_t> dimSizes(dimRank);
-  auto numPartitions = partDataLength / (dimRank * 2);
+  unsigned long numPartitions = partDataLength / (dimRank * 2);
   assert(partDataLength % (dimRank * 2) == 0 &&
          "Partition data len must be a multiple of dimension rank");
 


### PR DESCRIPTION
Since merging of #11 , my build faces a compilation error:

```
In file included from /Users/knliege/dev/llvm-kokkos/LAPIS/mlir/lib/ExecutionEngine/PartTensorRuntime.cpp:45:
In file included from /Users/knliege/dev/llvm-kokkos/LAPIS/mlir/include/mlir/ExecutionEngine/PartTensorRuntime.h:21:
/Users/knliege/dev/llvm-kokkos/LAPIS/mlir/include/mlir/ExecutionEngine/PartTensor/Storage.h:191:17: error: no matching function for call to 'seq'
  for (auto i : llvm::seq(0lu, numPartitions)) {
                ^~~~~~~~~
/Users/knliege/local/llvm-kokkos/include/llvm/ADT/Sequence.h:305:6: note: candidate template ignored: deduced conflicting types for parameter 'T' ('unsigned long' vs. 'uint64_t' (aka 'unsigned long long'))
auto seq(T Begin, T End) {
     ^
/Users/knliege/local/llvm-kokkos/include/llvm/ADT/Sequence.h:315:6: note: candidate function template not viable: requires single argument 'Size', but 2 arguments were provided
auto seq(T Size) {
     ^
1 error generated.
```

I am not sure why this started with #11 but this PR fixes it.