### PR TITLE
Explicitely add needed python packages

### DIFF
--- a/llvm/notchpeak.requirements.txt
+++ b/llvm/notchpeak.requirements.txt
@@ -1,2 +1,5 @@
 numpy==1.26.2
 pybind11
+
+# for testing
+PyYAML


### PR DESCRIPTION
The readme assumes required python packages are already installed. This PR
includes required packages in notchpeak.requirements.txt.