### PR TITLE
lapis-opt: guard pt dialect under ifdef

### DIFF
--- a/mlir/tools/lapis-opt/lapis-opt.cpp
+++ b/mlir/tools/lapis-opt/lapis-opt.cpp
@@ -40,9 +40,9 @@ int main(int argc, char **argv) {
       mlir::arith::ArithDialect, mlir::bufferization::BufferizationDialect,
       mlir::func::FuncDialect, mlir::linalg::LinalgDialect,
       mlir::memref::MemRefDialect, mlir::sparse_tensor::SparseTensorDialect,
-      mlir::tensor::TensorDialect,
+      mlir::tensor::TensorDialect, mlir::part_tensor::PartTensorDialect,
 #endif
-      mlir::kokkos::KokkosDialect, mlir::part_tensor::PartTensorDialect>();
+      mlir::kokkos::KokkosDialect>();
 
   // Register LAPIS pipelines and passes
 #ifdef ENABLE_PART_TENSOR


### PR DESCRIPTION
I enabled partTensor dialect by mistake even when PART_TENSOR_ENABLE was not on.