### PR TITLE
Register Kokkos pass dependencies in lapis-opt

### DIFF
--- a/mlir/tools/lapis-opt/lapis-opt.cpp
+++ b/mlir/tools/lapis-opt/lapis-opt.cpp
@@ -14,17 +14,18 @@
 #include "mlir/Dialect/Kokkos/Transforms/Passes.h"
 #include "mlir/Dialect/SparseTensor/Pipelines/Passes.h"
 #ifdef ENABLE_PART_TENSOR
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/PartTensor/IR/PartTensor.h"
 #include "mlir/Dialect/PartTensor/Pipelines/Passes.h"
 #include "mlir/Dialect/PartTensor/Transforms/Passes.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #endif
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 
@@ -37,12 +38,12 @@ int main(int argc, char **argv) {
   DialectRegistry registry;
   registry.insert<
 #ifdef ENABLE_PART_TENSOR
-      mlir::arith::ArithDialect, mlir::bufferization::BufferizationDialect,
-      mlir::func::FuncDialect, mlir::linalg::LinalgDialect,
-      mlir::memref::MemRefDialect, mlir::sparse_tensor::SparseTensorDialect,
+      mlir::bufferization::BufferizationDialect,
+      mlir::linalg::LinalgDialect,
+      mlir::sparse_tensor::SparseTensorDialect,
       mlir::tensor::TensorDialect, mlir::part_tensor::PartTensorDialect,
 #endif
-      mlir::kokkos::KokkosDialect>();
+      mlir::arith::ArithDialect, mlir::scf::SCFDialect, mlir::memref::MemRefDialect, mlir::func::FuncDialect, mlir::kokkos::KokkosDialect>();
 
   // Register LAPIS pipelines and passes
 #ifdef ENABLE_PART_TENSOR


### PR DESCRIPTION
Fixes lapis-opt commands with Kokkos dialect tests, like ``lapis-opt --parallel-unit-step  par_unit_stride_0.mlir``