### PR TITLE
Install lapis-opt, lapis-translate to bin

### DIFF
--- a/mlir/tools/lapis-opt/CMakeLists.txt
+++ b/mlir/tools/lapis-opt/CMakeLists.txt
@@ -11,9 +11,9 @@ target_link_libraries(lapis-opt
   MLIRParser
   LAPISPass
   MLIRSPIRVDialect
-  MLIRTranslateLib
   MLIRSupport
   MLIROptLib
   )
 
 mlir_check_link_libraries(lapis-opt)
+install(TARGETS lapis-opt)

--- a/mlir/tools/lapis-translate/CMakeLists.txt
+++ b/mlir/tools/lapis-translate/CMakeLists.txt
@@ -23,3 +23,4 @@ target_link_libraries(lapis-translate
   )
 
 mlir_check_link_libraries(lapis-translate)
+install(TARGETS lapis-translate)


### PR DESCRIPTION
Install the two main utilities, this lets users access the core functionality of LAPIS from an installation.