### PR TITLE
Fix build + tests + examples with PartTensor disabled

### DIFF
--- a/mlir/lib/Dialect/Kokkos/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/Kokkos/Pipelines/CMakeLists.txt
@@ -1,3 +1,7 @@
+IF(LAPIS_ENABLE_PART_TENSOR)
+  SET(PartTensorLibs "MLIRPartTensor MLIRPartTensorTransforms")
+ENDIF()
+
 add_mlir_dialect_library(MLIRKokkosPipelines
   KokkosPipelines.cpp
 
@@ -22,11 +26,10 @@ add_mlir_dialect_library(MLIRKokkosPipelines
   MLIRSCFToControlFlow
   MLIRKokkosDialect
   MLIRKokkosTransforms
-  MLIRPartTensor
-  MLIRPartTensorTransforms
   MLIRSparseTensorDialect
   MLIRSparseTensorTransforms
   MLIRTensorTransforms
   MLIRVectorToLLVM
   MLIRVectorTransforms
+  ${PartTensorLibs}
 )

--- a/mlir/lib/Dialect/Kokkos/Pipelines/KokkosPipelines.cpp
+++ b/mlir/lib/Dialect/Kokkos/Pipelines/KokkosPipelines.cpp
@@ -16,11 +16,13 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
-#include "mlir/Dialect/PartTensor/Transforms/Passes.h"
 #include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Dialect/SparseTensor/Transforms/Passes.h"
 #include "mlir/Dialect/Kokkos/IR/KokkosDialect.h"
 #include "mlir/Dialect/Kokkos/Transforms/Passes.h"
+#ifdef ENABLE_PART_TENSOR
+#include "mlir/Dialect/PartTensor/Transforms/Passes.h"
+#endif
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -34,7 +36,9 @@ using namespace mlir::kokkos;
 // Not working yet: new Kokkos dialect based pipeline.
 void mlir::kokkos::buildSparseKokkosCompiler(
     OpPassManager &pm, const SparseCompilerOptions &options) {
+#ifdef ENABLE_PART_TENSOR
   pm.addPass(::mlir::createPartTensorConversionPass());
+#endif
   pm.addNestedPass<func::FuncOp>(createLinalgGeneralizationPass());
   pm.addPass(createSparsificationAndBufferizationPass(
       getBufferizationOptionsForSparsification(


### PR DESCRIPTION
Fix build with ``-DLAPIS_ENABLE_PART_TENSOR=OFF``. Everything that uses just the Kokkos dialect and emitter should still work with this setting.