### PR TITLE
Enable configuration with part tensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,7 @@ set(CMAKE_BUILD_WITH_INSTALL_NAME_DIR ON)
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
 
 # Turn on part tensor dialect by default
-IF(NOT DEFINED LAPIS_ENABLE_PART_TENSOR)
-  SET(LAPIS_ENABLE_PART_TENSOR ON)
-ENDIF()
-
+option(LAPIS_ENABLE_PART_TENSOR "Enable the part tensor dialect" ON)
 if(LAPIS_ENABLE_PART_TENSOR)
   add_compile_definitions(ENABLE_PART_TENSOR)
 endif()

--- a/mlir/lib/Dialect/Kokkos/Pipelines/CMakeLists.txt
+++ b/mlir/lib/Dialect/Kokkos/Pipelines/CMakeLists.txt
@@ -1,5 +1,5 @@
 IF(LAPIS_ENABLE_PART_TENSOR)
-  SET(PartTensorLibs "MLIRPartTensor MLIRPartTensorTransforms")
+  SET(PartTensorLibs "MLIRPartTensor;MLIRPartTensorTransforms")
 ENDIF()
 
 add_mlir_dialect_library(MLIRKokkosPipelines


### PR DESCRIPTION
This PR only successfully enables cmake configuration of project with part
tensor ON. Later PR will address the actual code changes to address build
failures arising from newer LLVM. #35
