### PR TITLE
lapis-opt: register extensions needed for inlining

### DIFF
--- a/mlir/tools/lapis-opt/CMakeLists.txt
+++ b/mlir/tools/lapis-opt/CMakeLists.txt
@@ -2,16 +2,25 @@ get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
 add_llvm_executable(lapis-opt lapis-opt.cpp)
 llvm_update_compile_flags(lapis-opt)
+
 target_link_libraries(lapis-opt
   PRIVATE
   ${dialect_libs}
   ${translation_libs}
   ${test_libs}
-  MLIRIR
-  MLIRParser
-  MLIRSPIRVDialect
-  MLIRSupport
+
+  MLIRAffineAnalysis
+  MLIRAnalysis
+  MLIRCastInterfaces
+  MLIRDialect
   MLIROptLib
+  MLIRParser
+  MLIRPass
+  MLIRTransforms
+  MLIRTransformUtils
+  MLIRSupport
+  MLIRIR
+  MLIRFuncAllExtensions
   )
 
 mlir_check_link_libraries(lapis-opt)

--- a/mlir/tools/lapis-opt/lapis-opt.cpp
+++ b/mlir/tools/lapis-opt/lapis-opt.cpp
@@ -17,12 +17,14 @@
 #include "lapis/Dialect/PartTensor/Pipelines/Passes.h"
 #include "lapis/Dialect/PartTensor/Transforms/Passes.h"
 #endif
+#include "mlir/InitAllDialects.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/IR/ValueBoundsOpInterfaceImpl.h"
 #include "mlir/Dialect/Arith/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Extensions/AllExtensions.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/AllInterfaces.h"
 #include "mlir/Dialect/Linalg/Transforms/RuntimeOpVerification.h"
@@ -85,6 +87,9 @@ int main(int argc, char **argv) {
   tensor::registerTilingInterfaceExternalModels(registry);
   tensor::registerValueBoundsOpInterfaceExternalModels(registry);
   vector::registerBufferizableOpInterfaceExternalModels(registry);
+
+  LLVM::registerInlinerInterface(registry);
+  func::registerAllExtensions(registry);
 
   // Register LAPIS pipelines and passes
 #ifdef ENABLE_PART_TENSOR


### PR DESCRIPTION
``createInlinerPass()`` can be used in LAPIS pipelines where it didn't work before.

This was also needed to make lapis-opt work in debug builds, since something in the dialect registry was throwing when the inliner extensions were missing.

@a-alveyblanc This should fix the problems with inlining you had before. ``--inline`` is still not a flag that lapis-opt supports, but internally the pass works so other passes/pipelines can call it.