### PR TITLE
Emitter: arith.trunci support, avoid narrowing conversion warnings

### DIFF
--- a/benchmarks/spmv/main.cpp
+++ b/benchmarks/spmv/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, const char** argv) {
     Vector_DV y("y", A.numRows());
     Struct0 shape = {
       {A.numRows(), A.numCols()},
-      {A_rowptrs.extent(0), A_entries.extent(0), A_values.extent(0)}
+      {(int64_t) A_rowptrs.extent(0), (int64_t) A_entries.extent(0), (int64_t) A_values.extent(0)}
     };
     // Warmup
     spmv(A_rowptrs, A_entries, A_values, shape, x, y);

--- a/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
+++ b/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
@@ -3583,7 +3583,7 @@ LogicalResult KokkosCppEmitter::emitOperation(Operation &op, bool trailingSemico
           .Case<arith::AddFOp, arith::AddIOp, arith::SubFOp, arith::SubIOp, arith::MulFOp, arith::MulIOp, arith::DivFOp, arith::DivSIOp, arith::DivUIOp, arith::AndIOp, arith::OrIOp, arith::XOrIOp>(
               [&](auto op) { return printBinaryInfixOperation(*this, op); })
           // Arithmetic ops: type casting that C++ compiler can handle automatically with implicit conversion: "result = operand;"
-          .Case<arith::UIToFPOp, arith::FPToSIOp, arith::TruncFOp, arith::ExtFOp, arith::ExtSIOp, arith::ExtUIOp>(
+          .Case<arith::UIToFPOp, arith::FPToSIOp, arith::TruncIOp, arith::TruncFOp, arith::ExtFOp, arith::ExtSIOp, arith::ExtUIOp>(
               [&](auto op) { return printImplicitConversionOperation(*this, op); })
           // Arithmetic ops: min/max expressed using ternary operator.
           .Case<arith::MinimumFOp>(


### PR DESCRIPTION
- support ``arith.trunci`` op
- for arith (scalar level) casts, use C cast syntax to avoid warnings about narrowing
- ``memref.extract_strided_metadata`` op produces a bunch of results and some might be unused, so only declare those that are used
- spmv benchmark: avoid narrowing size_t -> int64 implicitly