### PR TITLE
Add pass to fold linalg.transpose on constant

### DIFF
--- a/mlir/include/lapis/Dialect/Kokkos/Transforms/Passes.h
+++ b/mlir/include/lapis/Dialect/Kokkos/Transforms/Passes.h
@@ -20,6 +20,8 @@ namespace mlir {
 #define GEN_PASS_DECL
 #include "lapis/Dialect/Kokkos/Transforms/Passes.h.inc"
 
+std::unique_ptr<Pass> createTransposeConstantFoldPass();
+
 std::unique_ptr<Pass> createMemrefResultsToParamsPass();
 
 std::unique_ptr<Pass> createMemrefToKokkosScratchPass();

--- a/mlir/include/lapis/Dialect/Kokkos/Transforms/Passes.td
+++ b/mlir/include/lapis/Dialect/Kokkos/Transforms/Passes.td
@@ -5,6 +5,14 @@
 
 include "mlir/Pass/PassBase.td"
 
+def TransposeConstantFoldPass : Pass<"fold-constant-transpose"> {
+  let summary = "Fold linalg.transpose ops with constant operands";
+  let dependentDialects = [
+    "affine::AffineDialect", "linalg::LinalgDialect", "memref::MemRefDialect"
+  ];
+  let constructor = "mlir::createTransposeConstantFoldPass()";
+}
+
 def MemrefResultsToParams : Pass<"memref-results-to-params", "ModuleOp"> {
   let summary = "Moves memref-type return values to be function parameters instead";
   let description = [{

--- a/mlir/lib/Dialect/Kokkos/Pipelines/KokkosPipelines.cpp
+++ b/mlir/lib/Dialect/Kokkos/Pipelines/KokkosPipelines.cpp
@@ -42,6 +42,10 @@ using namespace mlir::kokkos;
 void mlir::kokkos::buildSparseKokkosCompiler(
     OpPassManager &pm, const LapisCompilerOptions& options) {
   bool enableRuntimeLib = !options.decompose;
+
+  // Fold linalg.transpose on constant tensors
+  pm.addPass(::mlir::createTransposeConstantFoldPass());
+
 #ifdef LAPIS_ENABLE_PART_TENSOR
   pm.addPass(::mlir::createPartTensorConversionPass(options.partTensorBackend));
 #endif
@@ -143,6 +147,9 @@ void mlir::kokkos::buildSparseKokkosCompiler(
 }
 
 void mlir::kokkos::buildTeamLevelKokkosCompiler(OpPassManager &pm, const TeamLevelCompilerOptions& /*options*/) {
+  // Fold linalg.transpose on constant tensors
+  pm.addPass(::mlir::createTransposeConstantFoldPass());
+
   pm.addPass(createInlinerPass());
 
   // Rewrite named linalg ops into generic ops and apply fusion.

--- a/mlir/lib/Dialect/Kokkos/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/Kokkos/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_mlir_dialect_library(MLIRKokkosTransforms
+  TransposeConstantFold.cpp
   MemrefResultsToParams.cpp
   MemrefToKokkosScratch.cpp
   ParallelUnitStep.cpp

--- a/mlir/lib/Dialect/Kokkos/Transforms/TransposeConstantFold.cpp
+++ b/mlir/lib/Dialect/Kokkos/Transforms/TransposeConstantFold.cpp
@@ -1,0 +1,41 @@
+//===- TransposeConstantFold.cpp -===//
+// Pattern to fold linalg.transpose on constant tensors       //
+// This is just a driver for the pattern that lives in Linalg //
+
+#include "lapis/Dialect/Kokkos/IR/KokkosDialect.h"
+#include "lapis/Dialect/Kokkos/Transforms/Passes.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+using namespace mlir::kokkos;
+
+namespace mlir {
+#define GEN_PASS_DEF_TRANSPOSECONSTANTFOLDPASS
+#include "lapis/Dialect/Kokkos/Transforms/Passes.h.inc"
+}
+
+static bool alwaysFold(OpOperand*) {return true;}
+
+struct TransposeConstantFoldPass
+    : public impl::TransposeConstantFoldPassBase <TransposeConstantFoldPass> {
+
+  using impl::TransposeConstantFoldPassBase<TransposeConstantFoldPass>::TransposeConstantFoldPassBase;
+
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *context = op->getContext();
+    RewritePatternSet patterns(context);
+
+    linalg::populateConstantFoldLinalgOperations(patterns, alwaysFold);
+
+    (void) applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+std::unique_ptr<Pass> mlir::createTransposeConstantFoldPass() {
+  return std::make_unique<TransposeConstantFoldPass>();
+}
+


### PR DESCRIPTION
This is just some boilerplate to let lapis-opt drive the patterns already in linalg. Added to start of lapis pipelines, before generalize-named-ops happens.

This benefits MALA and ResNet (and probably many MLP/CNN models) which do initially store weights arrays in a different layout from how they are used.