### PR TITLE
Temporary workaround for #88

### DIFF
--- a/mlir/lib/Dialect/Kokkos/Pipelines/KokkosPipelines.cpp
+++ b/mlir/lib/Dialect/Kokkos/Pipelines/KokkosPipelines.cpp
@@ -139,7 +139,8 @@ void mlir::kokkos::buildSparseKokkosCompiler(
   // Ensure all casts are realized.
   pm.addPass(createReconcileUnrealizedCastsPass());
 
-  pm.addPass(createKokkosMdrangeIterationPass());
+  // TEMPORARY: disable this pass to avoid issues with spmv kernel (see #88)
+  //pm.addPass(createKokkosMdrangeIterationPass());
 
   // Finally, lower scf/memref to kokkos
   pm.addPass(createParallelUnitStepPass());


### PR DESCRIPTION
Comment out the kokkos-mdrange-iteration pass from pipeline for now, to avoid blocking other developers working off the main branch