### PR TITLE
Fix uninitialized result tensor in pcg's dot

### DIFF
--- a/examples/pcg_solve.py
+++ b/examples/pcg_solve.py
@@ -16,7 +16,8 @@ module {
   }
 
   func.func private @dot(%x: tensor<?xf64>, %y: tensor<?xf64>) -> f64 {
-    %0 = tensor.empty() : tensor<f64>
+    %f0 = arith.constant 0.0 : f64
+    %0 = tensor.splat %f0[] : tensor<f64>
     %dot = linalg.dot ins(%x, %y : tensor<?xf64>,tensor<?xf64>) outs(%0: tensor<f64>) -> tensor<f64>
     %6 = tensor.extract %dot[] : tensor<f64>
     return %6: f64


### PR DESCRIPTION
In the pcg_solve.py example, the dot product kernel used an uninitialized tensor as the result, possibly leading to an incorrect result (thanks @jpr-snl for catching this). This initializes dot's output tensor to 0.0. I verified the fix by running pcg in valgrind.