### PR TITLE
Fix kokkos.single failing to infer return type

### DIFF
--- a/mlir/include/lapis/Dialect/Kokkos/IR/KokkosDialect.td
+++ b/mlir/include/lapis/Dialect/Kokkos/IR/KokkosDialect.td
@@ -252,7 +252,7 @@ def ModifyOp : Kokkos_Op<"modify"> {
   let hasFolder = 0;
 }
 
-def SingleOp : Kokkos_Op<"single", [SingleBlockImplicitTerminator<"kokkos::YieldOp">, RecursiveMemoryEffects, NoRegionArguments, InferTypeOpAdaptor]> {
+def SingleOp : Kokkos_Op<"single", [SingleBlockImplicitTerminator<"kokkos::YieldOp">, RecursiveMemoryEffects, NoRegionArguments]> {
   let summary = "Restricts a block to execute exactly once per team or per thread";
   let description = [{
     "Restricts a block to execute exactly once per team or per thread"

--- a/mlir/lib/Dialect/Kokkos/IR/KokkosDialect.cpp
+++ b/mlir/lib/Dialect/Kokkos/IR/KokkosDialect.cpp
@@ -436,21 +436,6 @@ kokkos::UpdateReductionOp ThreadParallelOp::getReduction() {
   return nullptr;
 }
 
-// ********* //
-//  SingleOp //
-// ********* //
-
-LogicalResult mlir::kokkos::SingleOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location,
-    SingleOp::Adaptor adaptor, SmallVectorImpl<Type> &inferredReturnTypes) {
-  // Return types are identical to operand types:
-  // arguments on executing thread are broadcast to the rest of the team or
-  // thread
-  for (auto arg : adaptor.getOperands())
-    inferredReturnTypes.push_back(arg.getType());
-  return success();
-}
-
 // ******************** //
 //  UpdateReductionOp   //
 // ******************** //

--- a/mlir/lib/Dialect/Kokkos/Transforms/KokkosLoopMapping.cpp
+++ b/mlir/lib/Dialect/Kokkos/Transforms/KokkosLoopMapping.cpp
@@ -681,6 +681,7 @@ static LogicalResult insertSingleWraps(RewriterBase &rewriter,
                                        Region& region) {
   region.walk<WalkOrder::PostOrder>([&](Operation *op) {
     if (opNeedsSingle(op)) {
+      auto oldIP = rewriter.saveInsertionPoint();
       rewriter.setInsertionPoint(op);
       if (inTeamLoop(op) && !inThreadLoop(op)) {
         // op needs to be in PerTeam single
@@ -703,6 +704,7 @@ static LogicalResult insertSingleWraps(RewriterBase &rewriter,
                                          singleWrappedOp->getResults());
         rewriter.replaceOp(op, single);
       }
+      rewriter.restoreInsertionPoint(oldIP);
       return WalkResult::skip();
     }
     return WalkResult::advance();


### PR DESCRIPTION
Remove "infer return types" trait from ``kokkos.single`` op since we don't actually want that; its result types should always be provided to the op builder.