### PR TITLE
Fix emitter: kokkos.single op emitter w/broadcast

### DIFF
--- a/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
+++ b/mlir/lib/Target/KokkosCpp/TranslateToKokkosCpp.cpp
@@ -2115,7 +2115,12 @@ static LogicalResult printOperation(KokkosCppEmitter &emitter, kokkos::SingleOp 
     }
   }
   emitter.ostream().unindent();
-  emitter << "})";
+  emitter << "}";
+  // Finally, pass a reference to each output for receiving broadcasted values.
+  for(Value result : op->getResults()) {
+    emitter << ", " << emitter.getOrCreateName(result);
+  }
+  emitter << ")";
   return success();
 }
 

--- a/python/lapis/KokkosBackend.py
+++ b/python/lapis/KokkosBackend.py
@@ -172,8 +172,9 @@ class KokkosBackend:
             print("== After forward mode AD: ==")
             print(moduleText)
         # Finish lowering to Kokkos
+        # NOTE: re-run the whole pipeline since Enzyme introduces new linalg ops that must be lowered to scf.
         try:
-            moduleText = self.run_cli("lapis-opt", ['--sparse-compiler-kokkos-post-ad'], moduleText)
+            moduleText = self.run_cli("lapis-opt", ['--sparse-compiler-kokkos'], moduleText)
         except:
             raise Exception("Lowering to Kokkos dialect failed.")
         if self.dump_mlir:
@@ -240,7 +241,7 @@ class KokkosBackend:
             print(moduleText)
         # Finish lowering to Kokkos
         try:
-            moduleText = self.run_cli("lapis-opt", ['--sparse-compiler-kokkos-post-ad'], moduleText)
+            moduleText = self.run_cli("lapis-opt", ['--sparse-compiler-kokkos'], moduleText)
         except:
             raise Exception("Lowering to Kokkos dialect failed.")
         if self.dump_mlir:


### PR DESCRIPTION
In emitter, fix handling of kokkos.single op where there are one or more broadcasted values.

Drive-by change: run full lowering pipeline post-Enzyme in KokkosBackend.py, since Enzyme can re-introduce linalg ops that must be lowered to scf and then kokkos.