### PR TITLE
Add load_cpp utility

### DIFF
--- a/mlir/lib/Dialect/Kokkos/Pipelines/KokkosPipelines.cpp
+++ b/mlir/lib/Dialect/Kokkos/Pipelines/KokkosPipelines.cpp
@@ -143,7 +143,7 @@ void mlir::kokkos::buildSparseKokkosCompiler(
   // Ensure all casts are realized.
   pm.addPass(createReconcileUnrealizedCastsPass());
 
-  pm.addPass(createKokkosMdrangeIterationPass());
+  //pm.addPass(createKokkosMdrangeIterationPass());
 
   // Finally, lower scf/memref to kokkos
   pm.addPass(createParallelUnitStepPass());
@@ -259,7 +259,7 @@ void mlir::kokkos::buildSparseKokkosCompilerPreAD(
 
 void mlir::kokkos::buildSparseKokkosCompilerPostAD(
     OpPassManager &pm) {
-  pm.addPass(createKokkosMdrangeIterationPass());
+  //pm.addPass(createKokkosMdrangeIterationPass());
 
   // Finally, lower scf/memref to kokkos
   pm.addPass(createParallelUnitStepPass());

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -24,6 +24,7 @@ declare_mlir_python_sources(LapisPythonSources.kokkos_backend
   ADD_TO_PARENT LapisPythonSources
   SOURCES
     KokkosBackend.py
+    translate_old_to_new_mlir.py
 )
 
 set(_source_components

--- a/python/lapis/KokkosBackend.py
+++ b/python/lapis/KokkosBackend.py
@@ -121,6 +121,22 @@ class KokkosBackend:
         # And compile + load the module
         return self.compile_kokkos_to_native(moduleRoot, True)
 
+    # Note: cgeist supports ingesting either a single function or all functions ("*")
+    # For now, this interface supports just a single function.
+    # sysflags contains any additional flags (for example, to provide C++ stdlib headers) in order for cgeist to work.
+    def load_cpp(self, filename, function, sysflags=[]):
+        if 'KOKKOS_ROOT' not in os.environ:
+            raise Exception("load_cpp: Converting Kokkos C++ to MLIR requires $KOKKOS_ROOT to point to a valid Kokkos installation.")
+        cgeist=None
+        if 'CGEIST' in os.environ:
+            cgeist = os.environ['CGEIST']
+        else:
+            cgeist = shutil.which('cgeist')
+        if cgeist is None:
+            raise Exception("load_cpp: Could not find cgeist utility. Either add it to PATH or set $CGEIST to point to it directly.")
+        # Run cgeist on the given input file and capture only its output to stdout (containing the MLIR module)
+        return self.run_cli(cgeist, sysflags + ['-I', os.environ['KOKKOS_ROOT'] + '/include', filename, '--function=' + function, '--eliminate-polygeist-pointer', '--skip-licm', '-S'], "")
+
     def validate_activities(self, activities):
         pass
         #for a in activities:

--- a/python/lapis/KokkosBackend.py
+++ b/python/lapis/KokkosBackend.py
@@ -6,6 +6,7 @@ import subprocess
 import tempfile
 #import torch
 from shutil import which
+from lapis.translate_old_to_new_mlir import translate_old_to_new_mlir
 
 class KokkosBackend:
     """Main entry-point for the Kokkos backend for linalg-on-tensors dense/sparse code."""
@@ -135,7 +136,9 @@ class KokkosBackend:
         if cgeist is None:
             raise Exception("load_cpp: Could not find cgeist utility. Either add it to PATH or set $CGEIST to point to it directly.")
         # Run cgeist on the given input file and capture only its output to stdout (containing the MLIR module)
-        return self.run_cli(cgeist, sysflags + ['-I', os.environ['KOKKOS_ROOT'] + '/include', filename, '--function=' + function, '--eliminate-polygeist-pointer', '--skip-licm', '-S'], "")
+        module = self.run_cli(cgeist, sysflags + ['-I', os.environ['KOKKOS_ROOT'] + '/include', filename, '--function=' + function, '--eliminate-polygeist-pointer', '--skip-licm', '-S'], "")
+        module = translate_old_to_new_mlir(module)
+        return module
 
     def validate_activities(self, activities):
         pass

--- a/python/lapis/translate_old_to_new_mlir.py
+++ b/python/lapis/translate_old_to_new_mlir.py
@@ -1,0 +1,161 @@
+"""
+mlir_old_to_new.py
+
+Usage:
+  python3 mlir_old_to_new.py <input_old.mlir> [output_new.mlir]
+
+If output filename is omitted, writes transformed MLIR to stdout.
+
+Transforms:
+1) scf.parallel: delete only the final top-level `scf.yield` (with no operands)
+   in each scf.parallel body.
+2) scf.reduce typing:
+   Old: scf.reduce(%5)  : f64 {
+   New: scf.reduce(%5 : f64) {
+   (also handles trailing attributes/loc on the line)
+
+Note: code written by ChatGPT 5.2
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+
+# ----------------------------- Transform framework -----------------------------
+
+@dataclass
+class TransformResult:
+    text: str
+    changed: bool
+    count: int = 0
+
+
+class Transform:
+    name: str = "unnamed-transform"
+
+    def apply(self, text: str) -> TransformResult:
+        raise NotImplementedError
+
+
+def apply_transforms(text: str, transforms: Iterable[Transform]) -> Tuple[str, List[Tuple[str, int]]]:
+    stats: List[Tuple[str, int]] = []
+    for t in transforms:
+        res = t.apply(text)
+        text = res.text
+        stats.append((t.name, res.count))
+    return text, stats
+
+
+# ----------------------------- Transform #1 ------------------------------------
+
+class DeleteFinalParallelYieldTransform(Transform):
+    name = "scf.parallel: delete final top-level scf.yield()"
+
+    _parallel_start = re.compile(r"\bscf\.parallel\b.*\{")
+
+    _yield_no_operands = re.compile(
+        r"""^\s*scf\.yield(\s*(?:\{.*\})?\s*(?:loc\([^)]+\))?\s*(?::.*)?\s*)$"""
+    )
+
+    def apply(self, text: str) -> TransformResult:
+        lines = text.splitlines(keepends=True)
+
+        brace_level = 0
+        parallel_stack: List[dict] = []
+
+        changed = False
+        count = 0
+
+        for i, line in enumerate(lines):
+            starts_parallel = bool(self._parallel_start.search(line))
+            opens = line.count("{")
+            closes = line.count("}")
+
+            if starts_parallel:
+                body_level = brace_level + 1
+                parallel_stack.append({"body_level": body_level, "last_yield_line": None})
+
+            brace_level += opens
+
+            if parallel_stack:
+                ctx = parallel_stack[-1]
+                if brace_level == ctx["body_level"] and self._yield_no_operands.match(line):
+                    ctx["last_yield_line"] = i
+
+            for _ in range(closes):
+                brace_level -= 1
+                if parallel_stack and brace_level < parallel_stack[-1]["body_level"]:
+                    ctx = parallel_stack.pop()
+                    j = ctx["last_yield_line"]
+                    if j is not None:
+                        lines[j] = ""
+                        changed = True
+                        count += 1
+
+        return TransformResult("".join(lines), changed=changed, count=count)
+
+
+# ----------------------------- Transform #2 ------------------------------------
+# The earlier regex missed cases where the scf.reduce line ends with "{".
+# This version explicitly allows an optional "{" plus optional trailing text.
+
+class ReduceTypePlacementTransform(Transform):
+    name = "scf.reduce: move result type into operand list"
+
+    # Matches, e.g.:
+    #   scf.reduce(%5)  : f64 {
+    #   scf.reduce(%5) : memref<?xf64> loc(#loc)
+    #   %x = scf.reduce(%5) : f64 {   (assignment allowed)
+    #
+    # Captures:
+    #   pre   => up to "scf.reduce"
+    #   args  => inside (...)
+    #   type  => type after ':'
+    #   tail  => remaining suffix on the line (including "{" / attrs / loc), if any
+    _rx = re.compile(
+        r"""
+        ^(?P<pre>\s*(?:[%@][\w.$-]+\s*=\s*)?\s*scf\.reduce)\(
+            (?P<args>[^)]*)
+        \)
+        \s*:\s*
+        (?P<type>[^{}\n]+?)          # type token(s), stop before '{' or newline
+        (?P<tail>\s*(?:\{)?\s*(?:\{.*\})?\s*(?:loc\([^)]+\))?\s*)$
+        """,
+        flags=re.VERBOSE | re.MULTILINE,
+    )
+
+    def apply(self, text: str) -> TransformResult:
+        def repl(m: re.Match) -> str:
+            args = m.group("args")
+            # Already-new syntax if ":" appears inside parentheses.
+            if re.search(r"\S\s*:\s*\S", args):
+                return m.group(0)
+
+            pre = m.group("pre")
+            ty = m.group("type").strip()
+            tail = m.group("tail") or ""
+
+            if args.strip() == "":
+                return m.group(0)
+
+            return f"{pre}({args} : {ty}){tail}"
+
+        new_text, n = self._rx.subn(repl, text)
+        return TransformResult(new_text, changed=(n != 0), count=n)
+
+
+# ----------------------------- Main --------------------------------------------
+
+DEFAULT_TRANSFORMS: List[Transform] = [
+    DeleteFinalParallelYieldTransform(),
+    ReduceTypePlacementTransform(),
+]
+
+def translate_old_to_new_mlir(module):
+    out, _ = apply_transforms(module, DEFAULT_TRANSFORMS)
+    return out
+


### PR DESCRIPTION
Drives cgeist from python, so we can convert C++ to MLIR and immediately apply AD using the forward/reverse_diff_compile.
It also automatically updates the MLIR syntax from the Polygeist version to the LAPIS version.

Example:
```
    backend = KokkosBackend.KokkosBackend()
    # The array argument has flags needed for cgeist to find system includes, so that C++20 support works.
    module = backend.load_cpp('nrm2.cpp', 'nrm2', ['--sysroot=/usr', '-I', '/usr/lib/gcc/x86_64-redhat-linux/11/include'])
    print(module)
```

When nrm2 is a function in nrm2.cpp, this converts the function and prints:
```
module {
  func.func @nrm2(%arg0: memref<?xf32>) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
    %cst = arith.constant 0.000000e+00 : f32
    %c0 = arith.constant 0 : index
    %c1 = arith.constant 1 : index
    %dim = memref.dim %arg0, %c0 : memref<?xf32>
    %0 = scf.parallel (%arg1) = (%c0) to (%dim) step (%c1) init (%cst) -> f32 {
      %2 = memref.load %arg0[%arg1] : memref<?xf32>
      %3 = arith.mulf %2, %2 : f32
      %4 = arith.addf %3, %cst : f32
      scf.reduce(%4 : f32) {
      ^bb0(%arg2: f32, %arg3: f32):
        %5 = arith.addf %arg2, %arg3 : f32
        scf.reduce.return %5 : f32
      }
    }
    %1 = math.sqrt %0 : f32
    return %1 : f32
  }
}
```